### PR TITLE
Pin GitHub Actions to exact version hashes

### DIFF
--- a/.github/workflows/deploy-docx-strip-author.yml
+++ b/.github/workflows/deploy-docx-strip-author.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
-      - uses: aws-actions/setup-sam@v2
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      - uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63 # v2
+      - uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v4
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_STAGING_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -7,6 +7,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
+  "pip_requirements": {
+    "managerFilePatterns": ["/requirements/.*\\.txt/"]
+  }
 }


### PR DESCRIPTION
- Update Renovate configuration to use our [shared standard](https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/default.json)
- Update all GitHub Action dependencies to latest versions, and pin to exact hashes