### PR TITLE
Update pre-commit configuration to match FCL standards

### DIFF
--- a/.github/workflows/deploy-docx-strip-author.yml
+++ b/.github/workflows/deploy-docx-strip-author.yml
@@ -24,7 +24,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_STAGING_ROLE_ARN }}
           aws-region: eu-west-2
       - run: sam build --use-container -m lambda_strip_docx/requirements.txt
-      - run: >
+      - run: > # zizmor: ignore[template-injection]
           sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name da-caselaw-docx-strip-author --s3-bucket ingester-test-2 --capabilities CAPABILITY_IAM --region eu-west-2 --parameter-overrides
           AwsBucketName=${{ vars.PRIVATE_ASSET_BUCKET }}
           PublicAssetBucket=${{ vars.PUBLIC_ASSET_BUCKET }}

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -7,6 +7,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          SKIP: no-commit-to-branch

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -7,8 +7,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,4 +1,5 @@
 name: Pre-commit check
+permissions: {}
 on:
   pull_request:
     branches: ["main"]
@@ -8,7 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          persist-credentials: false
         env:
           SKIP: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,19 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-        exclude: ^template\.yml$
-    -   id: check-json
-    -   id: check-added-large-files
-    -   id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: check-yaml
+        exclude: ^template.yml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,15 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+        args: ["--baseline", ".secrets.baseline"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.17.1
+    hooks:
+      - id: mypy
+        files: ^lambda_strip_docx/
+        additional_dependencies:
+          - boto3-stubs[s3,sns]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
@@ -15,8 +15,14 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
--   repo: https://github.com/Yelp/detect-secrets
+  - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
-    -   id: detect-secrets
+      - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [yaml, json, markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json, markdown]
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.12.1
+    hooks:
+      - id: zizmor

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Removes author and related metadata from Microsoft Word DOCX files to ensure pri
 **Location:** `lambda_strip_docx/`
 
 **Key features:**
+
 - Accepts DOCX files as input (base64-encoded via API Gateway or S3 event).
 - Removes author metadata from document properties.
 - Preserves document content and formatting.
@@ -45,8 +46,6 @@ sam deploy --guided
 - See `.github/workflows/deploy-docx-strip-author.yml` for the CI/CD pipeline
 - See `template.yml` for the complete AWS SAM template defining both deployment options
 
-
-
 ### Local Development, Testing, and Deployment
 
 #### 1. Python Environment
@@ -65,7 +64,6 @@ Install the required dependencies for the DOCX Lambda:
 ```sh
 pip install -r lambda_strip_docx/requirements.txt
 ```
-
 
 #### 3. Run Unit Tests
 
@@ -119,14 +117,11 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-
 #### 6. Making Changes & Pull Requests
 
 - Ensure all tests pass locally before opening a PR.
 - Follow repo and code style guidelines.
 - Document any new environment variables or requirements in the README.
-
-
 
 #### 7. Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-pip install pre-commit
-
 # DA Caselaw Document Processing
 
 This repository contains AWS Lambda functions and supporting code for document processing in the DA Caselaw project.

--- a/template.yml
+++ b/template.yml
@@ -35,7 +35,6 @@ Parameters:
     Description: "VPC Security Group ID"
     Type: "String"
 
-
 Resources:
   TNACaselawDocxStripAuthorFunctionZip:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Refine the pre-commit configuration to better match the rest of the FCL codebase.

- Update the pre-commit stock hooks and run a more extensive set of them
- Add prettier to make sure various files are consistently formatted
- Add zizmor to run static analysis on workflows
- Fix zizmor findings
- Add mypy for code static analysis

## Still to do

We should follow up with PRs to:

- Add the lxml-stubs package to mypy and fix the findings
- Run mypy in strict mode and fix the findings
- Run ruff for code formatting (once other open PRs have been merged)