### PR TITLE
Remove remaining trivy references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,17 +47,6 @@ repos:
       - id: zizmor
         args: [--fix, --min-severity=low]
 
-  # - repo: https://github.com/antonbabenko/pre-commit-terraform
-  #   rev: v1.105.0
-  #   hooks:
-  #     - id: terraform_fmt
-  #     - id: terraform_tflint
-  #     - id: terraform_trivy
-  #       args:
-  #         - --hook-config=--parallelism-limit=1
-  #         - --args=--severity=CRITICAL
-  #         - --args=--ignorefile=__GIT_WORKING_DIR__/.trivyignore
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.4.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
       - id: zizmor
         args: [--fix, --min-severity=low]
 
+ - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.4.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: zizmor
         args: [--fix, --min-severity=low]
 
- - repo: https://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:
       - id: terraform_fmt

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,8 +1,0 @@
-# Trivy ignore file for terraform security scanning
-# This file allows us to ignore specific security findings that are false positives
-# or acceptable risks for this project
-
-# Example entries - customize based on actual findings:
-# AVD-AWS-0001
-# CVE-2021-12345
-# DS002


### PR DESCRIPTION
Clean up pre-commit config by removing commented out trivy hooks
Delete .trivyignore as we have removed trivy
Add back pre-commit hooks for Terraform formatting and linting