### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 set -e
 docker build -t docx-lambda-test -f **document_cleanser_lambda**/Dockerfile document_cleanser_lambda/
-docker run -d --name docx-lambda-test -p 9000:8080 docx-lambda-test
+docker run -d --name docx-lambda-test -p 127.0.0.1:9000:8080 -p [::1]:9000:8080 docx-lambda-test


### PR DESCRIPTION
https://docs.docker.com/engine/network/port-publishing/

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports)
