### PR TITLE
Update pdfcpu version

### DIFF
--- a/document_cleanser_lambda/Dockerfile
+++ b/document_cleanser_lambda/Dockerfile
@@ -30,7 +30,7 @@ RUN microdnf install -y \
         perl-4:5.32.1-477.amzn2023.0.7 \
         make-1:4.3-5.amzn2023.0.2 \
         # Dependencies needed for pdfcpu
-        golang-1.24.9-1.amzn2023.0.1 \
+        golang-1.25.8-1.amzn2023.0.1 \
         # QPDF for PDF processing
         qpdf-10.6.3-4.amzn2023.0.5 \
         && \
@@ -50,7 +50,7 @@ RUN wget https://github.com/exiftool/exiftool/archive/refs/tags/13.38.tar.gz && 
 RUN exiftool -ver
 
 # Install pdfcpu to /usr/local/bin (accessible by Lambda runtime user)
-RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v0.11.1 && \
+RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v0.13.0 && \
     cp /tmp/go/bin/pdfcpu /usr/local/bin/ && \
     chmod 755 /usr/local/bin/pdfcpu && \
     rm -rf /root/go && \

--- a/document_cleanser_lambda/clean_pdf.py
+++ b/document_cleanser_lambda/clean_pdf.py
@@ -17,22 +17,38 @@ def _qdf(filename: str) -> None:
 
 
 def _remove_annotations(filename: str) -> None:
-    subprocess.run([PDFCPU, "annot", "remove", filename], check=False, timeout=10, stdout=PIPE, stderr=STDOUT)
+    subprocess.run([PDFCPU, "annotations", "remove", filename], check=False, timeout=10, stdout=PIPE, stderr=STDOUT)
 
 
 def _remove_properties(filename: str) -> None:
     # Removing all the properties [nothing specified] does not appear to remove the predefined ones, like Author.
-    subprocess.run([PDFCPU, "prop", "remove", filename], timeout=10, check=True)
+    result = subprocess.run(
+        [PDFCPU, "properties", "remove", filename],
+        timeout=10,
+        check=False,
+        stdout=PIPE,
+        stderr=STDOUT,
+    )
+    # pdfcpu exits non-zero with "no property removed" when there are no custom properties to strip.
+    # That is not an error for our purposes, so only raise on any other failure.
+    if result.returncode != 0 and b"no property removed" not in result.stdout:
+        raise subprocess.CalledProcessError(result.returncode, result.args, output=result.stdout)
+
+    # Ensure predefined properties exist as pdfcpu exits non-zero otherwise.
+    # pdfcpu rejects empty values, so set placeholders that are removed immediately below.
     subprocess.run(
-        [PDFCPU, "prop", "add", filename, "Author=", "Subject=", "Title="],
+        [PDFCPU, "properties", "add", filename, "Author=Placeholder", "Subject=Placeholder", "Title=Placeholder"],
         timeout=10,
         check=True,
     )
-    subprocess.run(
-        [PDFCPU, "prop", "remove", filename, "Author", "Subject", "Title"],
-        timeout=10,
-        check=True,
-    )
+
+    # pdfcpu only removes the first named property per 'properties remove' call, so remove them individually.
+    for name in ("Author", "Subject", "Title"):
+        subprocess.run(
+            [PDFCPU, "properties", "remove", filename, name],
+            timeout=10,
+            check=True,
+        )
 
 
 def _info(filename: str) -> bytes:


### PR DESCRIPTION
Changes:
 - Bump Go version in Dockerfile to address reported CVEs.
 - Bump pdfcpu version in Dockerfile to address reported CVEs.
 - Update PDF cleansing logic to match pdfcpu’s new behavior and preserve existing output expectations.

[FCLC-2056](https://national-archives.atlassian.net/browse/FCLC-2056)

[FCLC-2056]: https://national-archives.atlassian.net/browse/FCLC-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ