### PR TITLE
Bump golang and remove go build cache

### DIFF
--- a/document_cleanser_lambda/Dockerfile
+++ b/document_cleanser_lambda/Dockerfile
@@ -30,7 +30,7 @@ RUN microdnf install -y \
         perl-4:5.32.1-477.amzn2023.0.7 \
         make-1:4.3-5.amzn2023.0.2 \
         # Dependencies needed for pdfcpu
-        golang-1.25.8-1.amzn2023.0.1 \
+        golang-1.25.10-1.amzn2023.0.1 \
         # QPDF for PDF processing
         qpdf-10.6.3-4.amzn2023.0.5 \
         && \
@@ -53,7 +53,7 @@ RUN exiftool -ver
 RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v0.13.0 && \
     cp /tmp/go/bin/pdfcpu /usr/local/bin/ && \
     chmod 755 /usr/local/bin/pdfcpu && \
-    rm -rf /root/go && \
+    rm -rf /tmp/go && \
     rm -rf /usr/lib/golang
 
 # Verify pdfcpu installation


### PR DESCRIPTION
Changes:
- Bump Go version in Dockerfile to address reported CVEs.
- Remove Go build cache after installing pdfcpu.

[FCLC-2056](https://national-archives.atlassian.net/browse/FCLC-2056)

[FCLC-2056]: https://national-archives.atlassian.net/browse/FCLC-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ