### PR TITLE
chore(lambda): remove unnecessary SQS lambda trigger maximum concurrency setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 It is part of the [TRE template repository](https://github.com/nationalarchives/da-tre-template)
 
+## [1.1.2] - 2026-08-10
+
+### Removed
+
+- Removed unnecessary maximum concurrency setting of the SQS trigger of the cleanser lambda
+
 ## [1.1.2] - 2026-06-26
 
 ### Added

--- a/document_cleanser_lambda/lambda_function.py
+++ b/document_cleanser_lambda/lambda_function.py
@@ -17,7 +17,7 @@ from exceptions import VisuallyDifferentError
 load_dotenv()
 
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 rollbar.init(os.getenv("ROLLBAR_TOKEN", ""), environment=os.getenv("ROLLBAR_ENV", "unknown"), code_version=__version__)
 
 DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -725,11 +725,6 @@ resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {
   # before the message goes to the DLQ (configured in SQS redrive_maximum_receives)
   function_response_types = ["ReportBatchItemFailures"] # Enable partial batch failures
 
-  # Scaling Configuration
-  scaling_config {
-    maximum_concurrency = 5 # Limit concurrent executions to prevent overwhelming Lambda
-  }
-
   depends_on = [
     aws_lambda_permission.allow_sqs_invoke,
     module.document_processing_queue


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-2264

chore(lambda): remove unnecessary SQS lambda trigger maximum concurrency setting

We noticed that the sqs queue has a max concurrency of 5. Not sure why we set it so low, the lambda would scale fine as well as s3. The cleanser does not touch marklogic. So we decided that we should just remove the max concurrency setting of the sqs trigger.